### PR TITLE
Add shim for gmsh.exe

### DIFF
--- a/gmsh/tools/chocolateyinstall.ps1
+++ b/gmsh/tools/chocolateyinstall.ps1
@@ -21,5 +21,8 @@ $exeLocation = "$installDir\$dirToExtract\gmsh.exe"
 # Create Start Menu shorcuts
 Install-ChocolateyShortcut -shortcutFilePath "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Gmsh\Gmsh.lnk" -targetPath $exeLocation -WorkingDirectory "$installDir\$dirToExtract" -IconLocation $exeLocation
 
+# Create shim
+Install-BinFile -Name "gmsh" -Path "$exeLocation"
+
 # Remove old version of Gmsh
 Get-ChildItem -Path $installDir -Exclude $dirToExtract | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue

--- a/gmsh/tools/chocolateyuninstall.ps1
+++ b/gmsh/tools/chocolateyuninstall.ps1
@@ -8,3 +8,6 @@ if (Test-Path $installDir) {
 
 # Delete additional shortcuts
 Remove-Item -Recurse "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Gmsh" -Force -ErrorAction SilentlyContinue
+
+# Delete shim
+Uninstall-BinFile -Name "gmsh"


### PR DESCRIPTION
So the executable is in PATH.

As a side note the package source in the chocolatey page is slightly wrong as it points to the gretl directory instead of gmsh